### PR TITLE
Fix prc timeout exception and make run configuration async validation

### DIFF
--- a/jetbrains-core/resources/META-INF/ext-rider.xml
+++ b/jetbrains-core/resources/META-INF/ext-rider.xml
@@ -7,6 +7,9 @@
         <component>
             <implementation-class>software.aws.toolkits.jetbrains.services.lambda.LambdaHost</implementation-class>
         </component>
+        <component>
+            <implementation-class>software.aws.toolkits.jetbrains.services.lambda.LambdaPsiHost</implementation-class>
+        </component>
     </project-components>
 
     <extensions defaultExtensionNs="com.intellij">

--- a/jetbrains-core/resources/META-INF/plugin.xml
+++ b/jetbrains-core/resources/META-INF/plugin.xml
@@ -166,6 +166,7 @@
                         serviceImplementation="software.aws.toolkits.jetbrains.core.DefaultAwsResourceCache"
                         testServiceImplementation="software.aws.toolkits.jetbrains.core.MockResourceCache"/>
         <projectService serviceImplementation="software.aws.toolkits.jetbrains.core.stack.StackWindowManager"/>
+        <projectService serviceImplementation="software.aws.toolkits.jetbrains.services.lambda.validation.LambdaHandlerValidator" />
         <toolWindow id="aws.explorer" anchor="left" secondary="true"
                     factoryClass="software.aws.toolkits.jetbrains.core.explorer.AwsExplorerFactory"
                     icon="AwsIcons.Logos.AWS"/>

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/Lambda.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/Lambda.kt
@@ -6,6 +6,8 @@ package software.aws.toolkits.jetbrains.services.lambda
 import com.intellij.openapi.project.Project
 import com.intellij.psi.NavigatablePsiElement
 import com.intellij.psi.search.GlobalSearchScope
+import org.jetbrains.concurrency.AsyncPromise
+import org.jetbrains.concurrency.Promise
 import software.amazon.awssdk.services.lambda.model.CreateFunctionResponse
 import software.amazon.awssdk.services.lambda.model.FunctionConfiguration
 import software.amazon.awssdk.services.lambda.model.GetFunctionConfigurationResponse

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfiguration.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfiguration.kt
@@ -10,6 +10,7 @@ import com.intellij.execution.configurations.ConfigurationFactory
 import com.intellij.execution.configurations.RefactoringListenerProvider
 import com.intellij.execution.configurations.RuntimeConfigurationError
 import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.components.service
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.options.SettingsEditorGroup
 import com.intellij.openapi.options.ShowSettingsUtil
@@ -30,17 +31,19 @@ import software.aws.toolkits.core.utils.getLogger
 import software.aws.toolkits.core.utils.info
 import software.aws.toolkits.core.utils.tryOrNull
 import software.aws.toolkits.jetbrains.services.lambda.Lambda.findPsiElementsForHandler
-import software.aws.toolkits.jetbrains.services.lambda.Lambda.isHandlerValid
 import software.aws.toolkits.jetbrains.services.lambda.LambdaHandlerResolver
 import software.aws.toolkits.jetbrains.services.lambda.RuntimeGroup
-import software.aws.toolkits.jetbrains.services.lambda.execution.LambdaRunConfigurationType
 import software.aws.toolkits.jetbrains.services.lambda.execution.LambdaRunConfigurationBase
+import software.aws.toolkits.jetbrains.services.lambda.execution.LambdaRunConfigurationType
 import software.aws.toolkits.jetbrains.services.lambda.runtimeGroup
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamCommon
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamOptions
-import software.aws.toolkits.jetbrains.services.lambda.sam.SamTemplateUtils.findFunctionsFromTemplate
+import software.aws.toolkits.jetbrains.services.lambda.sam.SamTemplateUtils
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamVersionCache
 import software.aws.toolkits.jetbrains.services.lambda.validOrNull
+import software.aws.toolkits.jetbrains.services.lambda.validation.LambdaHandlerEvaluationListener
+import software.aws.toolkits.jetbrains.services.lambda.validation.LambdaHandlerValidator
+import software.aws.toolkits.jetbrains.services.lambda.validation.SamCliVersionEvaluationListener
 import software.aws.toolkits.jetbrains.settings.AwsSettingsConfigurable
 import software.aws.toolkits.jetbrains.settings.SamSettings
 import software.aws.toolkits.resources.message
@@ -48,16 +51,18 @@ import java.nio.file.Path
 
 class LocalLambdaRunConfigurationFactory(configuration: LambdaRunConfigurationType) : ConfigurationFactory(configuration) {
     override fun createTemplateConfiguration(project: Project) = LocalLambdaRunConfiguration(project, this)
-
     override fun getName(): String = "Local"
 }
 
 class LocalLambdaRunConfiguration(project: Project, factory: ConfigurationFactory) :
     LambdaRunConfigurationBase<LocalLambdaOptions>(project, factory, "SAM CLI"),
     RefactoringListenerProvider {
+
     companion object {
         private val logger = getLogger<LocalLambdaRunConfiguration>()
     }
+
+    private val messageBus = project.messageBus
 
     override val lambdaOptions = LocalLambdaOptions()
 
@@ -69,18 +74,30 @@ class LocalLambdaRunConfiguration(project: Project, factory: ConfigurationFactor
     }
 
     override fun checkConfiguration() {
+        checkSamVersion()
+        resolveCredentials()
+        checkLambdaHandler()
+        checkRegion()
+        checkInput()
+    }
+
+    private fun checkSamVersion() {
         val executablePath = SamSettings.getInstance().executablePath
             ?: throw RuntimeConfigurationError(message("sam.cli_not_configured"))
 
         val promise = SamVersionCache.evaluate(executablePath)
-
         if (promise.isPending) {
+            promise.then { version ->
+                messageBus.syncPublisher(
+                    SamCliVersionEvaluationListener.TOPIC).samVersionValidationFinished(executablePath, version.result)
+            }
+
             logger.info { "Validation will proceed asynchronously for SAM CLI version" }
             throw RuntimeConfigurationError(message("lambda.run_configuration.sam.validation.in_progress"))
         }
 
         val errorMessage = try {
-            val semVer = promise.blockingGet(0)!!
+            val semVer = promise.blockingGet(0)!!.result
             SamCommon.getInvalidVersionMessage(semVer)
         } catch (e: Exception) {
             ExceptionUtil.getRootCause(e).message ?: message("general.unknown_error")
@@ -91,20 +108,35 @@ class LocalLambdaRunConfiguration(project: Project, factory: ConfigurationFactor
                 ShowSettingsUtil.getInstance().showSettingsDialog(project, AwsSettingsConfigurable::class.java)
             }
         }
+    }
 
-        resolveCredentials()
+    private fun checkLambdaHandler() {
+        val handlerValidator = project.service<LambdaHandlerValidator>()
+        val (handler, runtime) = resolveLambdaInfo(project = project, functionOptions = lambdaOptions.functionOptions)
+        val promise = handlerValidator.evaluate(LambdaHandlerValidator.LambdaEntry(project, runtime, handler))
 
-        val (handler, runtime) = resolveLambdaInfo()
-        if (!isHandlerValid(project, runtime, handler))
+        if (promise.isPending) {
+            promise.then { isValid ->
+                messageBus.syncPublisher(
+                    LambdaHandlerEvaluationListener.TOPIC).handlerValidationFinished(handler, isValid)
+            }
+
+            logger.info { "Validation will proceed asynchronously for SAM CLI version" }
+            throw RuntimeConfigurationError(message("lambda.run_configuration.handler.validation.in_progress"))
+        }
+
+        val isHandlerValid = promise.blockingGet(0)!!
+        if (!isHandlerValid)
             throw RuntimeConfigurationError(message("lambda.run_configuration.handler_not_found", handler))
+    }
 
+    private fun checkRegion() {
         regionId() ?: throw RuntimeConfigurationError(message("lambda.run_configuration.no_region_specified"))
-        checkInput()
     }
 
     override fun getState(executor: Executor, environment: ExecutionEnvironment): SamRunningState {
         try {
-            val (handler, runtime, templateDetails) = resolveLambdaInfo()
+            val (handler, runtime, templateDetails) = resolveLambdaInfo(project = project, functionOptions = lambdaOptions.functionOptions)
             val psiElement = handlerPsiElement(handler, runtime)
                 ?: throw RuntimeConfigurationError(message("lambda.run_configuration.handler_not_found", handler))
 
@@ -248,19 +280,16 @@ class LocalLambdaRunConfiguration(project: Project, factory: ConfigurationFactor
             ?.handlerDisplayName(handler) ?: handler
     }
 
-    private fun resolveLambdaInfo() = if (isUsingTemplate()) {
-        val templatePath = templateFile()
-            ?.takeUnless { it.isEmpty() }
+    private fun resolveLambdaFromTemplate(project: Project, templatePath: String?, functionName: String?): Triple<String, Runtime, SamTemplateDetails?> {
+        templatePath?.takeUnless { it.isEmpty() }
             ?: throw RuntimeConfigurationError(message("lambda.run_configuration.sam.no_template_specified"))
 
-        val functionName = logicalId() ?: throw RuntimeConfigurationError(
-            message("lambda.run_configuration.sam.no_function_specified")
-        )
+        functionName ?: throw RuntimeConfigurationError(message("lambda.run_configuration.sam.no_function_specified"))
 
         val templateFile = LocalFileSystem.getInstance().findFileByPath(templatePath)
             ?: throw RuntimeConfigurationError(message("lambda.run_configuration.sam.template_file_not_found"))
 
-        val function = findFunctionsFromTemplate(
+        val function = SamTemplateUtils.findFunctionsFromTemplate(
             project,
             templateFile
         ).find { it.logicalName == functionName }
@@ -274,18 +303,32 @@ class LocalLambdaRunConfiguration(project: Project, factory: ConfigurationFactor
 
         val handler = tryOrNull { function.handler() }
             ?: throw RuntimeConfigurationError(message("lambda.run_configuration.no_handler_specified"))
+
         val runtime = tryOrNull { Runtime.fromValue(function.runtime()).validOrNull }
             ?: throw RuntimeConfigurationError(message("lambda.run_configuration.no_runtime_specified"))
 
-        Triple(handler, runtime, SamTemplateDetails(VfsUtil.virtualToIoFile(templateFile).toPath(), functionName))
-    } else {
-        val handler = handler()
-            ?: throw RuntimeConfigurationError(message("lambda.run_configuration.no_handler_specified"))
-        val runtime = runtime()
-            ?: throw RuntimeConfigurationError(message("lambda.run_configuration.no_runtime_specified"))
-
-        Triple(handler, runtime, null)
+        return Triple(handler, runtime, SamTemplateDetails(VfsUtil.virtualToIoFile(templateFile).toPath(), functionName))
     }
+
+    private fun resolveLambdaFromHandler(handler: String?, runtime: Runtime?): Triple<String, Runtime, SamTemplateDetails?> {
+        handler ?: throw RuntimeConfigurationError(message("lambda.run_configuration.no_handler_specified"))
+        runtime ?: throw RuntimeConfigurationError(message("lambda.run_configuration.no_runtime_specified"))
+        return Triple(handler, runtime, null)
+    }
+
+    private fun resolveLambdaInfo(project: Project, functionOptions: FunctionOptions): Triple<String, Runtime, SamTemplateDetails?> =
+        if (functionOptions.useTemplate) {
+            resolveLambdaFromTemplate(
+                project = project,
+                templatePath = functionOptions.templateFile,
+                functionName = functionOptions.logicalId
+            )
+        } else {
+            resolveLambdaFromHandler(
+                handler = functionOptions.handler,
+                runtime = Runtime.fromValue(functionOptions.runtime)?.validOrNull
+            )
+        }
 
     private fun handlerPsiElement(handler: String? = handler(), runtime: Runtime? = runtime()) = try {
         runtime?.let {

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunSettingsEditorPanel.form
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunSettingsEditorPanel.form
@@ -3,7 +3,7 @@
   <grid id="12fa1" binding="panel" layout-manager="GridLayoutManager" row-count="10" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="774" height="524"/>
+      <xy x="20" y="20" width="854" height="524"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -191,6 +191,18 @@
           <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="7" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
       </nested-form>
+      <component id="53fcf" class="javax.swing.JCheckBox" binding="invalidator">
+        <constraints>
+          <grid row="2" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <alignmentY value="0.0"/>
+          <iconTextGap value="0"/>
+          <margin top="0" left="0" bottom="0" right="0"/>
+          <text value=""/>
+          <visible value="false"/>
+        </properties>
+      </component>
     </children>
   </grid>
 </form>

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/SamCommon.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/sam/SamCommon.kt
@@ -97,7 +97,7 @@ class SamCommon {
                 getInvalidVersionMessage(
                     SamVersionCache.evaluateBlocking(
                         sanitizedPath
-                    )
+                    ).result
                 )
             } catch (e: Exception) {
                 return e.message
@@ -112,7 +112,7 @@ class SamCommon {
                 ?: return "UNKNOWN"
 
             return try {
-                SamVersionCache.evaluateBlocking(sanitizedPath).rawVersion
+                SamVersionCache.evaluateBlocking(sanitizedPath).result.rawVersion
             } catch (e: Exception) {
                 logger.error(e) { "Error while getting SAM executable version." }
                 return "UNKNOWN"

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/validation/LambdaHandlerEvaluationListener.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/validation/LambdaHandlerEvaluationListener.kt
@@ -1,0 +1,21 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.lambda.validation
+
+import com.intellij.util.messages.Topic
+import java.util.EventListener
+
+/**
+ * This class represents a topic for Lambda Handler validation events.
+ */
+interface LambdaHandlerEvaluationListener : EventListener {
+    companion object {
+        val TOPIC = Topic("Lambda handler evaluation listener", LambdaHandlerEvaluationListener::class.java)
+    }
+
+    /**
+     * Lambda handler evaluation finished for the chosen profile, and it may be validated synchronously now.
+     */
+    fun handlerValidationFinished(handlerName: String, isHandlerExists: Boolean) {}
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/validation/LambdaHandlerValidator.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/validation/LambdaHandlerValidator.kt
@@ -1,0 +1,17 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.lambda.validation
+
+import com.intellij.openapi.project.Project
+import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.jetbrains.services.lambda.Lambda
+import software.aws.toolkits.jetbrains.utils.AsyncEvaluator
+
+class LambdaHandlerValidator : AsyncEvaluator<LambdaHandlerValidator.LambdaEntry, Boolean>() {
+
+    override fun getValue(entry: LambdaEntry): Boolean =
+        Lambda.isHandlerValid(entry.project, entry.runtime, entry.handler)
+
+    data class LambdaEntry(val project: Project, val runtime: Runtime, val handler: String)
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/validation/SamCliVersionEvaluationListener.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/services/lambda/validation/SamCliVersionEvaluationListener.kt
@@ -1,0 +1,22 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.lambda.validation
+
+import com.intellij.util.messages.Topic
+import com.intellij.util.text.SemVer
+import java.util.EventListener
+
+/**
+ * This class represents a topic for SAM CLI version validation events.
+ */
+interface SamCliVersionEvaluationListener : EventListener {
+    companion object {
+        val TOPIC = Topic("SAM CLI version evaluation listener", SamCliVersionEvaluationListener::class.java)
+    }
+
+    /**
+     * SAM CLI version evaluation finished for the chosen profile, and it may be validated synchronously now.
+     */
+    fun samVersionValidationFinished(path: String, version: SemVer) {}
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/AsyncEvaluator.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/AsyncEvaluator.kt
@@ -1,0 +1,110 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.utils
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.progress.ProcessCanceledException
+import org.jetbrains.annotations.TestOnly
+import org.jetbrains.concurrency.AsyncPromise
+import org.jetbrains.concurrency.Promise
+import org.jetbrains.concurrency.isPending
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import software.aws.toolkits.core.utils.info
+import java.util.concurrent.TimeUnit
+
+abstract class AsyncEvaluator<TEntry, TReturn> {
+
+    companion object {
+        private const val EVALUATE_BLOCKING_TIMEOUT_MS = 1000
+    }
+
+    private val logger: Logger = LoggerFactory.getLogger(this::class.java)
+    private val requests = hashMapOf<TEntry, Promise<TReturn>>()
+    private val lock = Object()
+
+    /**
+     * @return A promise for the requested file info. Promise will be resolved when the info is ready.
+     */
+    fun evaluate(entry: TEntry): Promise<TReturn> {
+        logger.info { "Evaluating $entry" }
+
+        val asyncPromise = AsyncPromise<TReturn>()
+        asyncPromise
+            .onSuccess { result ->
+                logger.info { "File info evaluation is completed: '$result'" }
+            }
+            .onError { error ->
+                // Need to set an error handler early, else the setError call will throw AssertionError
+                if (error !is ProcessCanceledException) {
+                    logger.info(error) { "Failed to evaluate ${entry.toString()}" }
+                }
+                clearRequest(entry)
+            }
+
+        val promise = synchronized(lock) {
+            val cachePromise = requests.getOrPut(entry) { asyncPromise }
+            if (!cachePromise.isPending && cachePromise.isSucceeded) {
+                if (isInvalidated(entry, cachePromise.blockingGet(0)!!)) {
+                    requests[entry] = asyncPromise
+                    return@synchronized asyncPromise
+                }
+            }
+            cachePromise
+        }
+
+        if (promise == asyncPromise) {
+            ApplicationManager.getApplication().executeOnPooledThread {
+                try {
+                    val result = getValue(entry)
+                    asyncPromise.setResult(result)
+                } catch (t: Throwable) {
+                    asyncPromise.setError(t)
+                }
+            }
+        }
+
+        return promise
+    }
+
+    abstract fun getValue(entry: TEntry): TReturn
+
+    open fun isInvalidated(entry: TEntry, value: TReturn): Boolean = false
+
+    fun evaluateBlocking(entry: TEntry, blockingTime: Int = EVALUATE_BLOCKING_TIMEOUT_MS, blockingUnit: TimeUnit = TimeUnit.MILLISECONDS): TReturn {
+        val promise = evaluate(entry)
+
+        if (!promise.isPending && !promise.isSucceeded)
+            throw IllegalStateException("Promise did not succeed successfully")
+
+        return promise.blockingGet(blockingTime, blockingUnit)!!
+    }
+
+    fun containsEntry(entry: TEntry): Boolean =
+        synchronized(lock) {
+            requests.containsKey(entry)
+        }
+
+    fun cancelRequests() {
+        requests.forEach { request ->
+            (request.value as? AsyncPromise)?.cancel()
+        }
+        clearRequests()
+    }
+
+    fun clearRequests() {
+        synchronized(lock) {
+            requests.clear()
+        }
+    }
+
+    private fun clearRequest(entry: TEntry) {
+        synchronized(lock) {
+            requests.remove(entry)
+        }
+    }
+
+    @TestOnly
+    fun testOnlyGetRequestCache() = requests
+}

--- a/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/FileInfoCache.kt
+++ b/jetbrains-core/src/software/aws/toolkits/jetbrains/utils/FileInfoCache.kt
@@ -3,110 +3,35 @@
 
 package software.aws.toolkits.jetbrains.utils
 
-import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.progress.ProcessCanceledException
-import org.jetbrains.annotations.TestOnly
-import org.jetbrains.concurrency.AsyncPromise
-import org.jetbrains.concurrency.Promise
-import org.jetbrains.concurrency.isPending
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
-import software.aws.toolkits.core.utils.info
 import software.aws.toolkits.resources.message
 import java.nio.file.Files
 import java.nio.file.NoSuchFileException
 import java.nio.file.Paths
 import java.time.Instant
-import java.util.concurrent.TimeUnit
 
 /**
  * Stores data related to a file path. Cache is invalidated when the cache entry is detected as stale.  Errors are
  * cached until the underlying path is detected as stale. Stale is defined as the cache entries (file modification time)[Files.getLastModifiedTime]
  * is older than the path's current modification time.
  */
-abstract class FileInfoCache<T> {
-    private val logger: Logger = LoggerFactory.getLogger(this::class.java)
-    private val infoCache = hashMapOf<String, InfoResult<T>>()
-    private val lock = Object()
+abstract class FileInfoCache<T> : AsyncEvaluator<String, FileInfoCache.InfoResult<T>>() {
 
-    /**
-     * @return A promise for the requested file info. Promise will be resolved when the info is ready.
-     */
-    fun evaluate(path: String): Promise<T> {
-        logger.info { "Evaluating $path" }
+    override fun getValue(entry: String): InfoResult<T> =
+        InfoResult(getFileInfo(entry), getLastModificationDate(entry))
 
-        val asyncPromise = AsyncPromise<T>()
-        asyncPromise
-            .onSuccess { result ->
-                logger.info { "File info evaluation is completed: '$result'" }
-            }
-            .onError { error -> // Need to set an error handler early, else the setError call will throw AssertionError
-                if (error !is ProcessCanceledException) {
-                    logger.info(error) { "Failed to evaluate $path" }
-                }
-            }
-
-        val infoResult = synchronized(lock) {
-            getCacheEntry(path, asyncPromise)
-        }
-
-        if (infoResult.result == asyncPromise && asyncPromise.isPending) {
-            ApplicationManager.getApplication().executeOnPooledThread {
-                try {
-                    val result = getFileInfo(path)
-                    asyncPromise.setResult(result)
-                } catch (t: Throwable) {
-                    asyncPromise.setError(t)
-                }
-            }
-        }
-
-        return infoResult.result
-    }
-
-    private fun getCacheEntry(path: String, asyncPromise: AsyncPromise<T>): InfoResult<T> {
-        val cacheEntry = infoCache[path]
-
-        val currentLastModificationDate = try {
-            Files.getLastModifiedTime(Paths.get(path)).toInstant()
-        } catch (e: NoSuchFileException) {
-            // If unable to get the current time, override the cache entry that the file can't be found
-
-            asyncPromise.setError(IllegalStateException(message("general.file_not_found", path)))
-
-            val newResult = InfoResult(asyncPromise, Instant.MIN)
-            infoCache[path] = newResult
-            return newResult
-        }
-
-        // If the promise is fulfilled, and the path has been modified since last checking, we need to check again
-        return if (cacheEntry == null ||
-            (!cacheEntry.result.isPending && currentLastModificationDate.isAfter(cacheEntry.timestamp))
-        ) {
-            logger.info { "InfoResult for $path is either missing, or stale. Checking again" }
-
-            val newResult = InfoResult(asyncPromise, currentLastModificationDate)
-            infoCache[path] = newResult
-            newResult
-        } else {
-            cacheEntry
-        }
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    fun evaluateBlocking(path: String, blockingTime: Int = 500, blockingUnit: TimeUnit = TimeUnit.MILLISECONDS): T {
-        val promise = evaluate(path)
-        return promise.blockingGet(blockingTime, blockingUnit).also {
-            if (!promise.isSucceeded) {
-                throw IllegalStateException("Promise did not succeed successfully")
-            }
-        } as T
-    }
-
-    @TestOnly
-    fun testOnlyGetRequestCache() = infoCache
+    override fun isInvalidated(entry: String, value: InfoResult<T>): Boolean =
+        getLastModificationDate(entry).isAfter(value.timestamp)
 
     protected abstract fun getFileInfo(path: String): T
 
-    data class InfoResult<T>(val result: Promise<T>, internal val timestamp: Instant)
+    private fun getLastModificationDate(path: String): Instant {
+        try {
+            return Files.getLastModifiedTime(Paths.get(path)).toInstant()
+        } catch (e: NoSuchFileException) {
+            // If unable to get the current time, override the cache entry that the file can't be found
+            throw IllegalStateException(message("general.file_not_found", path))
+        }
+    }
+
+    data class InfoResult<T>(val result: T, internal val timestamp: Instant)
 }

--- a/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfigurationTest.kt
+++ b/jetbrains-core/tst/software/aws/toolkits/jetbrains/services/lambda/execution/local/LocalLambdaRunConfigurationTest.kt
@@ -8,6 +8,7 @@ import com.intellij.execution.configurations.RuntimeConfigurationError
 import com.intellij.execution.executors.DefaultRunExecutor
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.VfsUtilCore
 import com.intellij.psi.PsiDocumentManager
@@ -26,7 +27,6 @@ import software.amazon.awssdk.services.lambda.model.Runtime
 import software.aws.toolkits.core.rules.EnvironmentVariableHelper
 import software.aws.toolkits.jetbrains.core.credentials.MockCredentialsManager
 import software.aws.toolkits.jetbrains.services.lambda.sam.SamCommonTestUtils
-import software.aws.toolkits.jetbrains.services.lambda.sam.SamVersionCache
 import software.aws.toolkits.jetbrains.settings.SamSettings
 import software.aws.toolkits.jetbrains.utils.rules.HeavyJavaCodeInsightTestFixtureRule
 import software.aws.toolkits.jetbrains.utils.rules.addClass
@@ -49,14 +49,14 @@ class LocalLambdaRunConfigurationTest {
 
     private val mockId = "MockCredsId"
     private val mockCreds = AwsBasicCredentials.create("Access", "ItsASecret")
+    private val runtime = Runtime.JAVA8
+    private val defaultHandler = "com.example.LambdaHandler::handleRequest"
 
     @Before
     fun setUp() {
         val validSam = SamCommonTestUtils.makeATestSam(SamCommonTestUtils.getMinVersionAsJson()).toString()
         SamSettings.getInstance().savedExecutablePath = validSam
-
-        // Pre-warm the SAM validation cache
-        SamVersionCache.evaluateBlocking(validSam, 2000)
+        preWarmSamVersionCache(validSam)
 
         MockCredentialsManager.getInstance().addCredentials(mockId, mockCreds)
 
@@ -83,14 +83,8 @@ class LocalLambdaRunConfigurationTest {
 
     @Test
     fun samIsNotSet() {
-        val fakeSamPath = "NotValid"
-        SamSettings.getInstance().savedExecutablePath = fakeSamPath
-        // Pre-warm the SAM validation cache
-        try {
-            SamVersionCache.evaluateBlocking(fakeSamPath)
-        } catch (e: Exception) {
-            // Do nothing
-        }
+        val invalidSamCliPath = "NotValid"
+        SamSettings.getInstance().savedExecutablePath = invalidSamCliPath
 
         runInEdtAndWait {
             val runConfiguration = createHandlerBasedRunConfiguration(
@@ -100,7 +94,7 @@ class LocalLambdaRunConfigurationTest {
             assertThat(runConfiguration).isNotNull
             assertThatThrownBy { runConfiguration.checkConfiguration() }
                 .isInstanceOf(RuntimeConfigurationError::class.java)
-                .hasMessageContaining("Invalid SAM CLI executable configured:")
+                .hasMessageContaining(message("lambda.run_configuration.sam.validation.in_progress"))
         }
     }
 
@@ -136,16 +130,20 @@ class LocalLambdaRunConfigurationTest {
 
     @Test
     fun handlerDoesNotExist() {
+        val project = projectRule.project
+        val invalidHandler = "Fake"
+        preWarmLambdaHandlerValidation(project, handler = invalidHandler)
+
         runInEdtAndWait {
             val runConfiguration = createHandlerBasedRunConfiguration(
-                project = projectRule.project,
-                handler = "Fake",
+                project = project,
+                handler = invalidHandler,
                 credentialsProviderId = mockId
             )
             assertThat(runConfiguration).isNotNull
             assertThatThrownBy { runConfiguration.checkConfiguration() }
                 .isInstanceOf(RuntimeConfigurationError::class.java)
-                .hasMessage(message("lambda.run_configuration.handler_not_found", "Fake"))
+                .hasMessage(message("lambda.run_configuration.handler_not_found", invalidHandler))
         }
     }
 
@@ -324,9 +322,11 @@ class LocalLambdaRunConfigurationTest {
 
     @Test
     fun invalidRegion() {
+        val project = projectRule.project
+        preWarmLambdaHandlerValidation(project)
         runInEdtAndWait {
             val runConfiguration = createHandlerBasedRunConfiguration(
-                project = projectRule.project,
+                project = project,
                 region = null,
                 credentialsProviderId = mockId
             )
@@ -368,9 +368,11 @@ class LocalLambdaRunConfigurationTest {
 
     @Test
     fun inputIsSet() {
+        val project = projectRule.project
+        preWarmLambdaHandlerValidation(project)
         runInEdtAndWait {
             val runConfiguration = createHandlerBasedRunConfiguration(
-                project = projectRule.project,
+                project = project,
                 credentialsProviderId = mockId,
                 input = "{}"
             )
@@ -381,9 +383,14 @@ class LocalLambdaRunConfigurationTest {
 
     @Test
     fun inputTextIsNotSet() {
+        val project = projectRule.project
+
+        preWarmSamVersionCache(SamSettings.getInstance().executablePath)
+        preWarmLambdaHandlerValidation(project)
+
         runInEdtAndWait {
             val runConfiguration = createHandlerBasedRunConfiguration(
-                project = projectRule.project,
+                project = project,
                 credentialsProviderId = mockId,
                 input = null
             )
@@ -396,9 +403,12 @@ class LocalLambdaRunConfigurationTest {
 
     @Test
     fun inputFileDoesNotExist() {
+        val project = projectRule.project
+        preWarmLambdaHandlerValidation(project)
+
         runInEdtAndWait {
             val runConfiguration = createHandlerBasedRunConfiguration(
-                project = projectRule.project,
+                project = project,
                 input = "DoesNotExist",
                 inputIsFile = true,
                 credentialsProviderId = mockId
@@ -412,11 +422,13 @@ class LocalLambdaRunConfigurationTest {
 
     @Test
     fun inputFileDoeExist() {
+        val project = projectRule.project
         val eventFile = projectRule.fixture.addFileToProject("event.json", "TestInputFile")
+        preWarmLambdaHandlerValidation(project)
 
         runInEdtAndWait {
             val runConfiguration = createHandlerBasedRunConfiguration(
-                project = projectRule.project,
+                project = project,
                 input = eventFile.virtualFile.path,
                 inputIsFile = true,
                 credentialsProviderId = mockId
@@ -681,6 +693,9 @@ class LocalLambdaRunConfigurationTest {
             assertThat(clonedConfiguration.inputSource()).isNotEqualTo(runConfiguration.inputSource())
         }
     }
+
+    private fun preWarmLambdaHandlerValidation(project: Project, handler: String = defaultHandler) =
+        preWarmLambdaHandlerValidation(project, runtime, handler)
 
     private fun getState(runConfiguration: LocalLambdaRunConfiguration): SamRunningState {
         val executor = ExecutorRegistry.getInstance().getExecutorById(DefaultRunExecutor.EXECUTOR_ID)

--- a/jetbrains-rider/ReSharper.AWS/src/AWS.Psi/Lambda/LambdaPsiHost.cs
+++ b/jetbrains-rider/ReSharper.AWS/src/AWS.Psi/Lambda/LambdaPsiHost.cs
@@ -1,0 +1,28 @@
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Host.Features;
+using JetBrains.Rider.Model;
+
+namespace AWS.Psi.Lambda
+{
+    [SolutionComponent]
+    public class LambdaPsiHost
+    {
+        private readonly LambdaPsiModel myModel;
+
+        public LambdaPsiHost(ISolution solution)
+        {
+            myModel = solution.GetProtocolSolution().GetLambdaPsiModel();
+
+            myModel.IsHandlerExists.Set((lifetime, handlerExistRequest) =>
+            {
+                var className = handlerExistRequest.ClassName;
+                var methodName = handlerExistRequest.MethodName;
+                var projectId = handlerExistRequest.ProjectId;
+
+                var backendPsiHelperModel = solution.GetProtocolSolution().GetBackendPsiHelperModel();
+                return backendPsiHelperModel.IsMethodExists.Handler.Invoke(
+                    lifetime, new MethodExistingRequest(className, methodName, "", projectId));
+            });
+        }
+    }
+}

--- a/jetbrains-rider/build.gradle
+++ b/jetbrains-rider/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 
 ext.resharperPluginPath = new File(projectDir, "ReSharper.AWS")
 
-def buildConfiguration = ext.properties["BuildConfiguration"] ?: "Debug"
+def buildConfiguration = ext.properties.get("BuildConfiguration") ?: "Debug"
 def pluginFiles = [
         "AWS.Localization/bin/$buildConfiguration/net461/AWS.Localization",
         "AWS.Daemon/bin/$buildConfiguration/net461/AWS.Daemon",
@@ -69,7 +69,7 @@ tasks.withType(prepareSandbox.class).all {
     doLast {
         files.each {
             def file = new File(it)
-            if (!file.isFile()) throw new GradleException("File $file does not exist")
+            if (!file.isFile()) throw new Throwable("File $file does not exist")
             logger.warn("$name: ${file.name} -> ${destinationDir}/${intellij.pluginName}/dotnet")
         }
     }

--- a/jetbrains-rider/protocol.gradle
+++ b/jetbrains-rider/protocol.gradle
@@ -3,14 +3,15 @@
 
 def protocolGroup = 'protocol'
 
-ext.csGeneratedOutput = new File(resharperPluginPath, "src/AWS.Daemon/Protocol")
+ext.csDaemonGeneratedOutput = new File(resharperPluginPath, "src/AWS.Daemon/Protocol")
+ext.csPsiGeneratedOutput = new File(resharperPluginPath, "src/AWS.Psi/Protocol")
+
 ext.ktGeneratedOutput = new File(projectDir, "src/software/aws/toolkits/jetbrains/protocol")
 
-task generateModel(type: tasks.getByName("rdgen").class) {
-    group = protocolGroup
-    description = 'Generates protocol models'
+ext.modelDir = new File(projectDir, "protocol/model")
 
-    def modelDir = new File(projectDir, "protocol/model")
+task generateDaemonModel(type: tasks.getByName("rdgen").class) {
+    def daemonModelSource = new File(modelDir, "daemon").canonicalPath
 
     // NOTE: classpath is evaluated lazily, at execution time, because it comes from the unzipped
     // intellij SDK, which is extracted in afterEvaluate
@@ -26,8 +27,8 @@ task generateModel(type: tasks.getByName("rdgen").class) {
 
             "$rdLibDirectory/rider-model.jar"
         }
-        sources modelDir.canonicalPath
-        packages = "protocol.model"
+        sources daemonModelSource
+        packages = "protocol.model.daemon"
 
         generator {
             language = "kotlin"
@@ -42,21 +43,66 @@ task generateModel(type: tasks.getByName("rdgen").class) {
             transform = "reversed"
             root = "com.jetbrains.rider.model.nova.ide.IdeRoot"
             namespace = "JetBrains.Rider.Model"
-            directory = "$csGeneratedOutput"
+            directory = "$csDaemonGeneratedOutput"
         }
     }
+}
+
+task generatePsiModel(type: tasks.getByName("rdgen").class) {
+    def psiModelSource = new File(modelDir, "psi").canonicalPath
+
+    // NOTE: classpath is evaluated lazily, at execution time, because it comes from the unzipped
+    // intellij SDK, which is extracted in afterEvaluate
+    params {
+        verbose = true
+        hashFolder = "build/rdgen"
+
+        logger.info("Configuring rdgen params")
+        classpath {
+            logger.info("Calculating classpath for rdgen, intellij.ideaDependency is: ${intellij.ideaDependency}")
+            def sdkPath = intellij.ideaDependency.classes
+            def rdLibDirectory = new File(sdkPath, "lib/rd").canonicalFile
+
+            "$rdLibDirectory/rider-model.jar"
+        }
+        sources psiModelSource
+        packages = "protocol.model.psi"
+
+        generator {
+            language = "kotlin"
+            transform = "asis"
+            root = "com.jetbrains.rider.model.nova.ide.IdeRoot"
+            namespace = "com.jetbrains.rider.model"
+            directory = "$ktGeneratedOutput"
+        }
+
+        generator {
+            language = "csharp"
+            transform = "reversed"
+            root = "com.jetbrains.rider.model.nova.ide.IdeRoot"
+            namespace = "JetBrains.Rider.Model"
+            directory = "$csPsiGeneratedOutput"
+        }
+    }
+}
+
+task generateModel(type: tasks.getByName("rdgen").class) {
+    group = protocolGroup
+    description = 'Generates protocol models'
+
+    dependsOn generateDaemonModel, generatePsiModel
 }
 
 task cleanProtocolModels {
     group = protocolGroup
     description = 'Clean up generated protocol models'
 
-    if (csGeneratedOutput.isDirectory()) {
-        csGeneratedOutput.deleteDir()
-    }
+    def protocolOutDirs = [ ktGeneratedOutput, csDaemonGeneratedOutput, csPsiGeneratedOutput ]
 
-    if (ktGeneratedOutput.isDirectory()) {
-        ktGeneratedOutput.deleteDir()
+    for (dir in protocolOutDirs) {
+        if (dir.isDirectory()) {
+            dir.deleteDir()
+        }
     }
 }
 

--- a/jetbrains-rider/protocol/model/daemon/LambdaModel.kt
+++ b/jetbrains-rider/protocol/model/daemon/LambdaModel.kt
@@ -1,7 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package protocol.model
+package protocol.model.daemon
 
 import com.jetbrains.rd.generator.nova.Ext
 import com.jetbrains.rd.generator.nova.doc

--- a/jetbrains-rider/protocol/model/psi/LambdaPsiModel.kt
+++ b/jetbrains-rider/protocol/model/psi/LambdaPsiModel.kt
@@ -1,0 +1,29 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package protocol.model.psi
+
+import com.jetbrains.rd.generator.nova.Ext
+import com.jetbrains.rd.generator.nova.async
+import com.jetbrains.rd.generator.nova.call
+import com.jetbrains.rd.generator.nova.doc
+import com.jetbrains.rd.generator.nova.field
+import com.jetbrains.rd.generator.nova.PredefinedType.bool
+import com.jetbrains.rd.generator.nova.PredefinedType.int
+import com.jetbrains.rd.generator.nova.PredefinedType.string
+import com.jetbrains.rider.model.nova.ide.SolutionModel
+
+@Suppress("unused")
+object LambdaPsiModel : Ext(SolutionModel.Solution) {
+
+    private val HandlerExistRequest = structdef {
+        field("className", string)
+        field("methodName", string)
+        field("projectId", int)
+    }
+
+    init {
+        call("isHandlerExists", HandlerExistRequest, bool).async
+            .doc("Check whether handler with specified name exists for a partucular project")
+    }
+}

--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/LambdaPsiHost.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/LambdaPsiHost.kt
@@ -1,0 +1,15 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.lambda
+
+import com.intellij.openapi.project.Project
+import com.jetbrains.rdclient.util.idea.LifetimedProjectComponent
+import com.jetbrains.rider.model.lambdaPsiModel
+import com.jetbrains.rider.projectView.solution
+
+@Suppress("ComponentNotRegistered")
+class LambdaPsiHost(project: Project) : LifetimedProjectComponent(project) {
+
+    val model = project.solution.lambdaPsiModel
+}

--- a/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamDebugSupport.kt
+++ b/jetbrains-rider/src/software/aws/toolkits/jetbrains/services/lambda/dotnet/DotNetSamDebugSupport.kt
@@ -280,12 +280,6 @@ class DotNetSamDebugSupport : SamDebugSupport {
         sessionModel: DotNetDebuggerSessionModel,
         outputEventsListener: IDebuggerOutputListener
     ): XDebugProcessStarter {
-        val consoleKind = ConsoleKind.ExternalConsole
-        (executionConsole as? ConsoleView)
-            ?.print(
-                "Input/Output redirection disabled: ${consoleKind.message}${System.lineSeparator()}",
-                ConsoleViewContentType.SYSTEM_OUTPUT
-            )
 
         val fireInitializedManually = env.getUserData(DotNetDebugRunner.FIRE_INITIALIZED_MANUALLY) ?: false
 

--- a/jetbrains-rider/tst/software/aws/toolkits/jetbrains/services/lambda/execution/local/DotNetLocalLambdaRunConfigurationTest.kt
+++ b/jetbrains-rider/tst/software/aws/toolkits/jetbrains/services/lambda/execution/local/DotNetLocalLambdaRunConfigurationTest.kt
@@ -1,0 +1,96 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.lambda.execution.local
+
+import com.intellij.execution.configurations.RuntimeConfigurationError
+import com.intellij.testFramework.runInEdtAndWait
+import com.jetbrains.rider.test.asserts.shouldNotBeNull
+import org.testng.annotations.Test
+import software.aws.toolkits.jetbrains.settings.SamSettings
+
+class DotNetLocalLambdaRunConfigurationTest : LambdaRunConfigurationTestBase() {
+
+    override fun getSolutionDirectoryName(): String = "SamHelloWorldApp"
+
+    @Test
+    fun testHandler_ValidHandler() {
+        preWarmSamVersionCache(SamSettings.getInstance().executablePath)
+        preWarmLambdaHandlerValidation(handler = defaultHandler)
+
+        runInEdtAndWait {
+            val runConfiguration = createHandlerBasedRunConfiguration(
+                handler = defaultHandler
+            )
+            runConfiguration.shouldNotBeNull()
+            runConfiguration.checkConfiguration()
+        }
+    }
+
+    @Test(
+        expectedExceptions = [ RuntimeConfigurationError::class ],
+        expectedExceptionsMessageRegExp = "Cannot find handler 'HelloWorld::HelloWorld.Function::HandlerDoesNoteExist' in project.")
+    fun testHandler_NonExistingMethodName() {
+        val nonExistingHandler = "HelloWorld::HelloWorld.Function::HandlerDoesNoteExist"
+        preWarmSamVersionCache(SamSettings.getInstance().executablePath)
+        preWarmLambdaHandlerValidation(handler = nonExistingHandler)
+
+        runInEdtAndWait {
+            val runConfiguration = createHandlerBasedRunConfiguration(
+                handler = nonExistingHandler
+            )
+            runConfiguration.shouldNotBeNull()
+            runConfiguration.checkConfiguration()
+        }
+    }
+
+    @Test(
+        expectedExceptions = [ RuntimeConfigurationError::class ],
+        expectedExceptionsMessageRegExp = "Cannot find handler 'HelloWorld::HelloWorld.UnknownFunction::FunctionHandler' in project.")
+    fun testHandler_NonExistingTypeName() {
+        val nonExistingHandler = "HelloWorld::HelloWorld.UnknownFunction::FunctionHandler"
+        preWarmSamVersionCache(SamSettings.getInstance().executablePath)
+        preWarmLambdaHandlerValidation(handler = nonExistingHandler)
+
+        runInEdtAndWait {
+            val runConfiguration = createHandlerBasedRunConfiguration(
+                handler = nonExistingHandler
+            )
+            runConfiguration.shouldNotBeNull()
+            runConfiguration.checkConfiguration()
+        }
+    }
+
+    @Test(
+        expectedExceptions = [ RuntimeConfigurationError::class ],
+        expectedExceptionsMessageRegExp = "Cannot find handler 'Fake' in project.")
+    fun testHandler_InvalidHandlerString() {
+        val invalidHandler = "Fake"
+        preWarmSamVersionCache(SamSettings.getInstance().executablePath)
+        preWarmLambdaHandlerValidation(handler = invalidHandler)
+
+        runInEdtAndWait {
+            val runConfiguration = createHandlerBasedRunConfiguration(
+                handler = invalidHandler
+            )
+            runConfiguration.shouldNotBeNull()
+            runConfiguration.checkConfiguration()
+        }
+    }
+
+    @Test(
+        expectedExceptions = [ RuntimeConfigurationError::class ],
+        expectedExceptionsMessageRegExp = "Must specify a handler.")
+    fun testHandler_HandlerNotSet() {
+        preWarmSamVersionCache(SamSettings.getInstance().executablePath)
+        preWarmLambdaHandlerValidation()
+
+        runInEdtAndWait {
+            val runConfiguration = createHandlerBasedRunConfiguration(
+                handler = null
+            )
+            runConfiguration.shouldNotBeNull()
+            runConfiguration.checkConfiguration()
+        }
+    }
+}

--- a/jetbrains-rider/tst/software/aws/toolkits/jetbrains/services/lambda/execution/local/LambdaRunConfigurationTestBase.kt
+++ b/jetbrains-rider/tst/software/aws/toolkits/jetbrains/services/lambda/execution/local/LambdaRunConfigurationTestBase.kt
@@ -1,0 +1,48 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.aws.toolkits.jetbrains.services.lambda.execution.local
+
+import com.jetbrains.rider.test.base.BaseTestWithSolution
+import org.testng.annotations.AfterMethod
+import org.testng.annotations.BeforeMethod
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.services.lambda.model.Runtime
+import software.aws.toolkits.jetbrains.core.credentials.MockCredentialsManager
+import software.aws.toolkits.jetbrains.services.lambda.sam.SamCommonTestUtils
+import software.aws.toolkits.jetbrains.settings.SamSettings
+
+abstract class LambdaRunConfigurationTestBase : BaseTestWithSolution() {
+
+    protected val mockId = "MockCredsId"
+    protected val mockCreds = AwsBasicCredentials.create("Access", "ItsASecret")
+
+    protected val runtime = Runtime.DOTNETCORE2_1
+    protected val defaultHandler = "HelloWorld::HelloWorld.Function::FunctionHandler"
+    protected val defaultInput = "inputText"
+
+    @BeforeMethod
+    fun setUpCredentialsManager() {
+        val validSam = SamCommonTestUtils.makeATestSam(SamCommonTestUtils.getMinVersionAsJson()).toString()
+        SamSettings.getInstance().savedExecutablePath = validSam
+
+        MockCredentialsManager.getInstance().addCredentials(mockId, mockCreds)
+    }
+
+    @AfterMethod
+    fun resetCredentialsManager() {
+        MockCredentialsManager.getInstance().reset()
+    }
+
+    protected fun createHandlerBasedRunConfiguration(handler: String? = defaultHandler,
+                                                     input: String? = defaultInput): LocalLambdaRunConfiguration =
+        createHandlerBasedRunConfiguration(
+            project = project,
+            runtime = runtime,
+            handler = handler,
+            input = input,
+            credentialsProviderId = mockId)
+
+    protected fun preWarmLambdaHandlerValidation(handler: String = defaultHandler) =
+        preWarmLambdaHandlerValidation(project, runtime, handler)
+}

--- a/resources/resources/software/aws/toolkits/resources/localized_messages.properties
+++ b/resources/resources/software/aws/toolkits/resources/localized_messages.properties
@@ -117,6 +117,7 @@ lambda.credentials.label=Credentials:
 lambda.run_configuration.description=Invoke AWS Lambda Function
 lambda.run_configuration.no_handler_specified=Must specify a handler.
 lambda.run_configuration.handler_not_found=Cannot find handler ''{0}'' in project.
+lambda.run_configuration.handler.validation.in_progress=Lambda handler validation is in progress
 lambda.run.configuration.handler_root_not_found=Failed to locate the root of the handler
 lambda.run_configuration.no_runtime_specified=Must specify supported runtime.
 lambda.run_configuration.input_file_error=Failed to load input file: {0}


### PR DESCRIPTION
* Replace the lamda run configuraiton validation logic from sync check for handler to async validation using cache system
* Add async protocol call to define if handler valid to be able to get results from any thread
* Fix local lambda run configuration form to re-validate itself when event is fired (async validation is finished)
* Refactor existing cache code to generalize it over other requests
* Add tests to verify handler validation logic with DotNet runtime
* Minor updates in Debugger - remove the debug message from output
* Fix read action exception while getting PSI element

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Description

## Motivation and Context

## Related Issue(s)
None

## Testing

## Screenshots (if appropriate)

## Checklist
- [x] I have read the **README** document
- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `gradlew check` succeeds
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] A short description of the change has been added to the **CHANGELOG**

## License
I confirm that my contribution is made under the terms of the Apache 2.0 license.
